### PR TITLE
feat: criar grade visual de horários académicos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+cat > .gitignore << 'EOF'
+.next/
+node_modules/
+.env
+.env.local
+EOF

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ cat > .gitignore << 'EOF'
 node_modules/
 .env
 .env.local
+docker-compose.yml
 EOF

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,16 @@
 import { DashboardLayout } from "@/components/dashboard-layout"
 import { DashboardContent } from "@/components/dashboard-content"
 import { getDashboardStats, getAulasHoje } from "./dashboard-action"
+import { getProfessoresDisponibilidade } from "@/lib/actions/horarios"
 
 export default async function DashboardPage() {
   const [stats, aulasHoje] = await Promise.all([
     getDashboardStats(),
     getAulasHoje(),
   ])
+
+  const professoresDisponibilidade = await getProfessoresDisponibilidade()
+  console.log(professoresDisponibilidade)
 
   return (
     <DashboardLayout>

--- a/components/app-header.tsx
+++ b/components/app-header.tsx
@@ -29,9 +29,8 @@ export function AppHeader() {
       <div className="flex items-center gap-4">
         <Button variant="ghost" size="icon" className="relative">
           <Bell className="h-5 w-5" />
-          <span className="absolute -right-0.5 -top-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-primary text-[10px] font-medium text-primary-foreground">
-            3
-          </span>
+          {/*<span className="absolute -right-0.5 -top-0.5 flex h-4 w-4 items-center justify-center rounded-full text-[10px] font-medium text-primary-foreground">
+          </span> */}
         </Button>
         
         <DropdownMenu>

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -37,7 +37,7 @@ export function AppSidebar() {
         <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary">
           <Calendar className="h-4 w-4 text-primary-foreground" />
         </div>
-        <span className="text-lg font-semibold text-sidebar-foreground">ScheduleGen</span>
+        <span className="text-lg font-semibold text-sidebar-foreground"> AURA </span>
       </div>
       
       <nav className="flex-1 space-y-1 p-4">

--- a/components/data-table.tsx
+++ b/components/data-table.tsx
@@ -89,7 +89,7 @@ export function DataTable<T extends { id: string | number }>({
                 </TableHead>
               ))}
               {(onEdit || onDelete) && (
-                <TableHead className="w-12 text-muted-foreground">Acoes</TableHead>
+                <TableHead className="w-12 text-muted-foreground"> Acções </TableHead>
               )}
             </TableRow>
           </TableHeader>

--- a/components/horarios-content.tsx
+++ b/components/horarios-content.tsx
@@ -3,92 +3,74 @@
 import { useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from "@/components/ui/select"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Calendar, Download, Printer, ChevronLeft, ChevronRight } from "lucide-react"
 
-const diasSemana = ["Segunda", "Terca", "Quarta", "Quinta", "Sexta"]
-const tempos = [
-  { id: "1", inicio: "08:00", fim: "08:50" },
-  { id: "2", inicio: "08:55", fim: "09:45" },
-  { id: "3", inicio: "10:05", fim: "10:55" },
-  { id: "4", inicio: "11:00", fim: "11:50" },
-  { id: "5", inicio: "11:55", fim: "12:45" },
-  { id: "6", inicio: "14:00", fim: "14:50" },
-  { id: "7", inicio: "14:55", fim: "15:45" },
-  { id: "8", inicio: "16:00", fim: "16:50" },
-  { id: "9", inicio: "16:55", fim: "17:45" },
+// ── DADOS FIXOS ───────────────────────────────────────────────
+// Estes virão da DB no futuro — por agora são fixos para montar a estrutura
+
+const diasSemana = ["2ª FEIRA", "3ª FEIRA", "4ª FEIRA", "5ª FEIRA", "6ª FEIRA"]
+
+// Cada entrada é uma linha da tabela — pode ser aula ou intervalo
+type LinhaTabela =
+  | { tipo: "aula";      tempo: string; horaInicio: string; horaFim: string; ordem: number }
+  | { tipo: "intervalo"; horaInicio: string; horaFim: string }
+
+const linhasManha: LinhaTabela[] = [
+  { tipo: "aula",      tempo: "1º manhã",  horaInicio: "7H30",  horaFim: "8H15",  ordem: 1 },
+  { tipo: "aula",      tempo: "2º manhã",  horaInicio: "8H15",  horaFim: "9H00",  ordem: 2 },
+  { tipo: "intervalo", horaInicio: "9H00",  horaFim: "9H15" },
+  { tipo: "aula",      tempo: "3º manhã",  horaInicio: "9H15",  horaFim: "10H00", ordem: 3 },
+  { tipo: "aula",      tempo: "4º manhã",  horaInicio: "10H00", horaFim: "10H45", ordem: 4 },
+  { tipo: "intervalo", horaInicio: "10H45", horaFim: "11H00" },
+  { tipo: "aula",      tempo: "5º manhã",  horaInicio: "11H00", horaFim: "11H45", ordem: 5 },
+  { tipo: "aula",      tempo: "6º manhã",  horaInicio: "11H45", horaFim: "12H30", ordem: 6 },
 ]
 
-const turmas = ["10A", "10B", "11A", "11B", "12A", "12B", "9A", "9B"]
-const professores = ["Maria Silva", "Joao Santos", "Ana Costa", "Pedro Oliveira", "Sofia Ferreira", "Carlos Rodrigues"]
+const linhasTarde: LinhaTabela[] = [
+  { tipo: "aula",      tempo: "1º tarde",  horaInicio: "13H00", horaFim: "13H45", ordem: 1 },
+  { tipo: "aula",      tempo: "2º tarde",  horaInicio: "13H45", horaFim: "14H30", ordem: 2 },
+  { tipo: "intervalo", horaInicio: "14H30", horaFim: "14H45" },
+  { tipo: "aula",      tempo: "3º tarde",  horaInicio: "14H45", horaFim: "15H30", ordem: 3 },
+  { tipo: "aula",      tempo: "4º tarde",  horaInicio: "15H30", horaFim: "16H15", ordem: 4 },
+  { tipo: "intervalo", horaInicio: "16H15", horaFim: "16H30" },
+  { tipo: "aula",      tempo: "5º tarde",  horaInicio: "16H30", horaFim: "17H15", ordem: 5 },
+  { tipo: "aula",      tempo: "6º tarde",  horaInicio: "17H15", horaFim: "18H00", ordem: 6 },
+]
+
+const turmas = ["10A", "10B", "11A", "11B", "12A", "12B"]
+const professores = ["Maria Silva", "João Santos", "Ana Costa", "Pedro Oliveira"]
+
+// ── TIPOS ─────────────────────────────────────────────────────
 
 interface Aula {
   disciplina: string
-  professor: string
-  sala: string
-  cor: string
+  professor:  string
+  sala:       string
+  cor:        string
 }
 
+// horario[turma][periodo][dia][ordem] → Aula | null
+// periodo: "manha" | "tarde"
 type HorarioData = {
   [turma: string]: {
-    [dia: string]: {
-      [tempo: string]: Aula | null
+    [periodo: string]: {
+      [dia: string]: {
+        [ordem: number]: Aula | null
+      }
     }
   }
 }
 
-const generateMockHorario = (): HorarioData => {
-  const disciplinas = [
-    { nome: "Matematica", cor: "#ef4444" },
-    { nome: "Portugues", cor: "#3b82f6" },
-    { nome: "Fisica", cor: "#22c55e" },
-    { nome: "Ingles", cor: "#a855f7" },
-    { nome: "Historia", cor: "#f97316" },
-    { nome: "Ed. Fisica", cor: "#ec4899" },
-    { nome: "Biologia", cor: "#eab308" },
-  ]
-  
-  const salas = ["Sala 101", "Sala 102", "Sala 201", "Lab. Fisica", "Lab. Info", "Ginasio"]
-  
-  const horario: HorarioData = {}
-  
-  turmas.forEach((turma) => {
-    horario[turma] = {}
-    diasSemana.forEach((dia) => {
-      horario[turma][dia] = {}
-      tempos.forEach((tempo) => {
-        if (Math.random() > 0.15) {
-          const disciplina = disciplinas[Math.floor(Math.random() * disciplinas.length)]
-          horario[turma][dia][tempo.id] = {
-            disciplina: disciplina.nome,
-            professor: professores[Math.floor(Math.random() * professores.length)],
-            sala: salas[Math.floor(Math.random() * salas.length)],
-            cor: disciplina.cor,
-          }
-        } else {
-          horario[turma][dia][tempo.id] = null
-        }
-      })
-    })
-  })
-  
-  return horario
-}
-
-const mockHorario = generateMockHorario()
+// ── COMPONENTE ────────────────────────────────────────────────
 
 export function HorariosContent() {
-  const [selectedTurma, setSelectedTurma] = useState("10A")
+  const [selectedTurma,    setSelectedTurma]    = useState(turmas[0])
   const [selectedProfessor, setSelectedProfessor] = useState("")
-  const [viewType, setViewType] = useState("turma")
+  const [viewType,          setViewType]          = useState("turma")
 
   const turmaIndex = turmas.indexOf(selectedTurma)
 
@@ -99,23 +81,227 @@ export function HorariosContent() {
     }
   }
 
+  // Futuramente este horario virá da API
+  // Por agora é null em todo o lado — células vazias
+  const horario: HorarioData = {}
+
+  const getAula = (
+    turma: string,
+    periodo: string,
+    dia: string,
+    ordem: number
+  ): Aula | null => {
+    return horario[turma]?.[periodo]?.[dia]?.[ordem] ?? null
+  }
+
+  // ── CÉLULA DE AULA ──────────────────────────────────────────
+
+  const CelulaAula = ({ aula }: { aula: Aula | null }) => {
+    if (aula) {
+      return (
+        <div
+          className="flex h-full min-h-16 flex-col justify-center rounded-sm p-1 text-white text-xs"
+          style={{ backgroundColor: aula.cor }}
+        >
+          <div className="font-semibold">Disc. {aula.disciplina}</div>
+          <div>Prof. {aula.professor}</div>
+          <div className="opacity-80">Sala {aula.sala}</div>
+        </div>
+      )
+    }
+    // célula vazia — mostra a estrutura mas sem dados
+    return (
+      <div className="flex h-full min-h-16 flex-col justify-center p-1 text-xs text-muted-foreground">
+        <div>Disc.</div>
+        <div>Prof.</div>
+        <div>Sala</div>
+      </div>
+    )
+  }
+
+  // ── TABELA (manhã ou tarde) ──────────────────────────────────
+
+  const TabelaPeriodo = ({
+    linhas,
+    periodo,
+    turma,
+  }: {
+    linhas: LinhaTabela[]
+    periodo: string  // "manha" | "tarde"
+    turma: string
+  }) => (
+    <table className="w-full border-collapse text-sm">
+      <thead>
+        <tr>
+          <th className="border border-border bg-muted p-2 text-left text-xs font-medium w-16">
+            TEMPO
+          </th>
+          <th className="border border-border bg-muted p-2 text-left text-xs font-medium w-16">
+            HORA
+          </th>
+          {diasSemana.map((dia) => (
+            <th
+              key={dia}
+              className="border border-border bg-muted p-2 text-center text-xs font-medium"
+            >
+              {dia}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {linhas.map((linha, i) => {
+
+          // ── LINHA DE INTERVALO ───────────────────────────────
+          if (linha.tipo === "intervalo") {
+            return (
+              <tr key={`interv-${i}`} className="bg-muted/30">
+                <td className="border border-border p-1 text-xs font-medium text-center">
+                  INTERV.
+                </td>
+                <td className="border border-border p-1 text-xs text-center">
+                  <div>{linha.horaInicio}</div>
+                  <div>{linha.horaFim}</div>
+                </td>
+                {/* células do intervalo — vazias e cinzentas */}
+
+                <td
+                  className="border border-border bg-muted/20 p-1"
+                  colSpan={diasSemana.length}
+                />
+              </tr>
+            )
+          }
+
+          // ── LINHA DE AULA ────────────────────────────────────
+          return (
+            <tr key={`aula-${linha.ordem}`}>
+              <td className="border border-border bg-muted/50 p-2 text-xs font-medium">
+                {linha.tempo}
+              </td>
+              <td className="border border-border bg-muted/50 p-1 text-xs text-center">
+                <div className="font-medium">{linha.horaInicio}</div>
+                <div className="text-muted-foreground">{linha.horaFim}</div>
+              </td>
+              {diasSemana.map((dia) => {
+                const aula = getAula(turma, periodo, dia, linha.ordem)
+                return (
+                  <td key={dia} className="border border-border p-1">
+                    <CelulaAula aula={aula} />
+                  </td>
+                )
+              })}
+            </tr>
+          )
+        })}
+      </tbody>
+    </table>
+  )
+
+  // ── TABELA DO PROFESSOR ──────────────────────────────────────
+
+  const TabelaProfessor = ({ professor }: { professor: string }) => (
+    <>
+      {[
+        { linhas: linhasManha, periodo: "manha", titulo: "Manhã" },
+        { linhas: linhasTarde, periodo: "tarde", titulo: "Tarde" },
+      ].map(({ linhas, periodo, titulo }) => (
+        <div key={periodo} className="space-y-1">
+          <h3 className="text-sm font-semibold text-muted-foreground">{titulo}</h3>
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse text-sm">
+              <thead>
+                <tr>
+                  <th className="border border-border bg-muted p-2 text-left text-xs font-medium w-16">TEMPO</th>
+                  <th className="border border-border bg-muted p-2 text-left text-xs font-medium w-16">HORA</th>
+                  {diasSemana.map((dia) => (
+                    <th key={dia} className="border border-border bg-muted p-2 text-center text-xs font-medium">
+                      {dia}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {linhas.map((linha, i) => {
+                  if (linha.tipo === "intervalo") {
+                    return (
+                      <tr key={`interv-${i}`} className="bg-muted/30">
+                        <td className="border border-border p-1 text-xs font-medium text-center">INTERV.</td>
+                        <td className="border border-border p-1 text-xs text-center">
+                          <div>{linha.horaInicio}</div>
+                          <div>{linha.horaFim}</div>
+                        </td>
+                        {diasSemana.map((dia) => (
+                          <td key={dia} className="border border-border bg-muted/20 p-1" />
+                        ))}
+                      </tr>
+                    )
+                  }
+
+                  return (
+                    <tr key={`aula-${linha.ordem}`}>
+                      <td className="border border-border bg-muted/50 p-2 text-xs font-medium">{linha.tempo}</td>
+                      <td className="border border-border bg-muted/50 p-1 text-xs text-center">
+                        <div className="font-medium">{linha.horaInicio}</div>
+                        <div className="text-muted-foreground">{linha.horaFim}</div>
+                      </td>
+                      {diasSemana.map((dia) => {
+                        // procura em todas as turmas se este professor tem aula neste slot
+                        let aulaProf: { turma: string; aula: Aula } | null = null
+                        for (const t of turmas) {
+                          const aula = getAula(t, periodo, dia, linha.ordem)
+                          if (aula?.professor === professor) {
+                            aulaProf = { turma: t, aula }
+                            break
+                          }
+                        }
+                        return (
+                          <td key={dia} className="border border-border p-1">
+                            {aulaProf ? (
+                              <div
+                                className="flex h-full min-h-16 flex-col justify-center rounded-sm p-1 text-white text-xs"
+                                style={{ backgroundColor: aulaProf.aula.cor }}
+                              >
+                                <div className="font-semibold">Disc. {aulaProf.aula.disciplina}</div>
+                                <div>Turma {aulaProf.turma}</div>
+                                <div className="opacity-80">Sala {aulaProf.aula.sala}</div>
+                              </div>
+                            ) : (
+                              <div className="flex h-full min-h-16 flex-col justify-center p-1 text-xs text-muted-foreground">
+                                <div>Disc.</div>
+                                <div>Turma</div>
+                                <div>Sala</div>
+                              </div>
+                            )}
+                          </td>
+                        )
+                      })}
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ))}
+    </>
+  )
+
+  // ── RENDER PRINCIPAL ─────────────────────────────────────────
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold tracking-tight">Horarios</h1>
-          <p className="text-muted-foreground">
-            Visualizar e gerir horarios de turmas e professores
-          </p>
+          <h1 className="text-3xl font-bold tracking-tight">Horários</h1>
+          <p className="text-muted-foreground">Visualizar e gerir horários de turmas e professores</p>
         </div>
         <div className="flex items-center gap-2">
           <Button variant="outline" className="gap-2 bg-transparent">
-            <Download className="h-4 w-4" />
-            Exportar
+            <Download className="h-4 w-4" /> Exportar
           </Button>
           <Button variant="outline" className="gap-2 bg-transparent">
-            <Printer className="h-4 w-4" />
-            Imprimir
+            <Printer className="h-4 w-4" /> Imprimir
           </Button>
         </div>
       </div>
@@ -126,11 +312,11 @@ export function HorariosContent() {
           <TabsTrigger value="professor">Por Professor</TabsTrigger>
         </TabsList>
 
+        {/* ── TAB TURMA ───────────────────────────────────────── */}
         <TabsContent value="turma" className="space-y-4">
           <div className="flex items-center gap-4">
             <Button
-              variant="outline"
-              size="icon"
+              variant="outline" size="icon"
               onClick={() => navigateTurma(-1)}
               disabled={turmaIndex === 0}
             >
@@ -141,16 +327,13 @@ export function HorariosContent() {
                 <SelectValue placeholder="Selecionar turma" />
               </SelectTrigger>
               <SelectContent>
-                {turmas.map((turma) => (
-                  <SelectItem key={turma} value={turma}>
-                    Turma {turma}
-                  </SelectItem>
+                {turmas.map((t) => (
+                  <SelectItem key={t} value={t}>Turma {t}</SelectItem>
                 ))}
               </SelectContent>
             </Select>
             <Button
-              variant="outline"
-              size="icon"
+              variant="outline" size="icon"
               onClick={() => navigateTurma(1)}
               disabled={turmaIndex === turmas.length - 1}
             >
@@ -161,73 +344,47 @@ export function HorariosContent() {
           <Card>
             <CardHeader className="flex flex-row items-center gap-2">
               <Calendar className="h-5 w-5 text-primary" />
-              <CardTitle>Horario da Turma {selectedTurma}</CardTitle>
+              <CardTitle>Horário da Turma {selectedTurma}</CardTitle>
             </CardHeader>
-            <CardContent>
-              <div className="overflow-x-auto">
-                <table className="w-full border-collapse">
-                  <thead>
-                    <tr>
-                      <th className="border border-border bg-muted p-3 text-left text-sm font-medium">
-                        Tempo
-                      </th>
-                      {diasSemana.map((dia) => (
-                        <th
-                          key={dia}
-                          className="border border-border bg-muted p-3 text-center text-sm font-medium"
-                        >
-                          {dia}
-                        </th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {tempos.map((tempo) => (
-                      <tr key={tempo.id}>
-                        <td className="border border-border bg-muted/50 p-3 text-sm">
-                          <div className="font-medium">{tempo.inicio}</div>
-                          <div className="text-xs text-muted-foreground">{tempo.fim}</div>
-                        </td>
-                        {diasSemana.map((dia) => {
-                          const aula = mockHorario[selectedTurma]?.[dia]?.[tempo.id]
-                          return (
-                            <td key={dia} className="border border-border p-1">
-                              {aula ? (
-                                <div
-                                  className="flex h-full min-h-16 flex-col justify-center rounded-md p-2 text-white"
-                                  style={{ backgroundColor: aula.cor }}
-                                >
-                                  <div className="font-medium text-sm">{aula.disciplina}</div>
-                                  <div className="text-xs opacity-90">{aula.professor}</div>
-                                  <div className="text-xs opacity-75">{aula.sala}</div>
-                                </div>
-                              ) : (
-                                <div className="flex h-full min-h-16 items-center justify-center text-muted-foreground">
-                                  -
-                                </div>
-                              )}
-                            </td>
-                          )
-                        })}
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+            <CardContent className="space-y-6">
+
+              {/* MANHÃ */}
+              <div className="space-y-1">
+                <h3 className="text-sm font-semibold text-muted-foreground">Manhã</h3>
+                <div className="overflow-x-auto">
+                  <TabelaPeriodo
+                    linhas={linhasManha}
+                    periodo="manha"
+                    turma={selectedTurma}
+                  />
+                </div>
               </div>
+
+              {/* TARDE */}
+              <div className="space-y-1">
+                <h3 className="text-sm font-semibold text-muted-foreground">Tarde</h3>
+                <div className="overflow-x-auto">
+                  <TabelaPeriodo
+                    linhas={linhasTarde}
+                    periodo="tarde"
+                    turma={selectedTurma}
+                  />
+                </div>
+              </div>
+
             </CardContent>
           </Card>
         </TabsContent>
 
+        {/* ── TAB PROFESSOR ────────────────────────────────────── */}
         <TabsContent value="professor" className="space-y-4">
           <Select value={selectedProfessor} onValueChange={setSelectedProfessor}>
             <SelectTrigger className="w-60">
               <SelectValue placeholder="Selecionar professor" />
             </SelectTrigger>
             <SelectContent>
-              {professores.map((professor) => (
-                <SelectItem key={professor} value={professor}>
-                  {professor}
-                </SelectItem>
+              {professores.map((p) => (
+                <SelectItem key={p} value={p}>{p}</SelectItem>
               ))}
             </SelectContent>
           </Select>
@@ -236,106 +393,21 @@ export function HorariosContent() {
             <Card>
               <CardHeader className="flex flex-row items-center gap-2">
                 <Calendar className="h-5 w-5 text-primary" />
-                <CardTitle>Horario de {selectedProfessor}</CardTitle>
+                <CardTitle>Horário de {selectedProfessor}</CardTitle>
               </CardHeader>
-              <CardContent>
-                <div className="overflow-x-auto">
-                  <table className="w-full border-collapse">
-                    <thead>
-                      <tr>
-                        <th className="border border-border bg-muted p-3 text-left text-sm font-medium">
-                          Tempo
-                        </th>
-                        {diasSemana.map((dia) => (
-                          <th
-                            key={dia}
-                            className="border border-border bg-muted p-3 text-center text-sm font-medium"
-                          >
-                            {dia}
-                          </th>
-                        ))}
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {tempos.map((tempo) => (
-                        <tr key={tempo.id}>
-                          <td className="border border-border bg-muted/50 p-3 text-sm">
-                            <div className="font-medium">{tempo.inicio}</div>
-                            <div className="text-xs text-muted-foreground">{tempo.fim}</div>
-                          </td>
-                          {diasSemana.map((dia) => {
-                            let professorAula: { turma: string; aula: Aula } | null = null
-                            for (const turma of turmas) {
-                              const aula = mockHorario[turma]?.[dia]?.[tempo.id]
-                              if (aula?.professor === selectedProfessor) {
-                                professorAula = { turma, aula }
-                                break
-                              }
-                            }
-                            return (
-                              <td key={dia} className="border border-border p-1">
-                                {professorAula ? (
-                                  <div
-                                    className="flex h-full min-h-16 flex-col justify-center rounded-md p-2 text-white"
-                                    style={{ backgroundColor: professorAula.aula.cor }}
-                                  >
-                                    <div className="font-medium text-sm">{professorAula.aula.disciplina}</div>
-                                    <div className="text-xs opacity-90">Turma {professorAula.turma}</div>
-                                    <div className="text-xs opacity-75">{professorAula.aula.sala}</div>
-                                  </div>
-                                ) : (
-                                  <div className="flex h-full min-h-16 items-center justify-center text-muted-foreground">
-                                    -
-                                  </div>
-                                )}
-                              </td>
-                            )
-                          })}
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
+              <CardContent className="space-y-6">
+                <TabelaProfessor professor={selectedProfessor} />
               </CardContent>
             </Card>
           ) : (
             <Card>
               <CardContent className="flex h-64 items-center justify-center">
-                <p className="text-muted-foreground">
-                  Selecione um professor para visualizar o horario
-                </p>
+                <p className="text-muted-foreground">Selecione um professor para visualizar o horário</p>
               </CardContent>
             </Card>
           )}
         </TabsContent>
       </Tabs>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Legenda</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="flex flex-wrap gap-3">
-            {[
-              { nome: "Matematica", cor: "#ef4444" },
-              { nome: "Portugues", cor: "#3b82f6" },
-              { nome: "Fisica", cor: "#22c55e" },
-              { nome: "Ingles", cor: "#a855f7" },
-              { nome: "Historia", cor: "#f97316" },
-              { nome: "Ed. Fisica", cor: "#ec4899" },
-              { nome: "Biologia", cor: "#eab308" },
-            ].map((disciplina) => (
-              <div key={disciplina.nome} className="flex items-center gap-2">
-                <div
-                  className="h-4 w-4 rounded"
-                  style={{ backgroundColor: disciplina.cor }}
-                />
-                <span className="text-sm">{disciplina.nome}</span>
-              </div>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
     </div>
   )
 }


### PR DESCRIPTION
## O que foi feito
Implementação da grade visual de horários académicos com separação
entre período da manhã e tarde, fiel ao formato usado pela instituição.

## Detalhes técnicos
- Componente horarios-content.tsx com grelha semanal completa
- Tipo LinhaTabela para distinguir linhas de aula e de intervalo
- Linhas de intervalo com colSpan para fusão correcta das células
- Períodos da manhã (7H30–12H30) e tarde (13H00–18H00) separados
- Actions do servidor em horarios.ts para buscar dados reais da BD
- Integração na página principal e navegação no sidebar e header

## Closes
Closes #2